### PR TITLE
Adds support for headers & body to web requests. 

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -15,6 +15,17 @@
   alert:  ./slack
   notify: me@localhost
 
+# Check with header values:
+- web:     http://127.0.0.1
+  headers:
+    Authorization: BASIC Zm9vOmJhcg==
+    Accept: text/plain
+
+# Check with post:
+- web:  http://127.0.0.1
+  body: |
+    { "animal": "elephant" }
+
 # Pings once in 2 seconds:
 - shell:  ping -c 1 192.168.6.1
   repeat: 2


### PR DESCRIPTION
 Configs have two new attributes: `headers` and `body`.  `headers` is a map, which are added to the request as headers. Web configs with a `body` attribute are automatically submitted as `POST`s with the body as the payload.